### PR TITLE
Support firehose in region ca-central-1

### DIFF
--- a/priv/endpoints.exs
+++ b/priv/endpoints.exs
@@ -48,6 +48,7 @@
             "ap-northeast-1" => %{},
             "ap-southeast-1" => %{},
             "ap-southeast-2" => %{},
+            "ca-central-1" => %{},
             "eu-central-1" => %{},
             "eu-west-1" => %{},
             "eu-west-3" => %{},


### PR DESCRIPTION
Following previous https://github.com/ex-aws/ex_aws/pull/717 🤦‍♀️ 

`(RuntimeError) firehose not supported in region ca-central-1 for partition aws`